### PR TITLE
chore(deps): add Dependabot maintenance config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Summary
- Add weekly Dependabot checks for npm dependencies
- Limit open version-update PRs to 2 to reduce maintenance noise

## Changed paths
- .github/dependabot.yml

## Verification
- Parsed .github/dependabot.yml with Ruby YAML.load_file
- No package manifests or lockfiles changed
