### PR TITLE
fix: normalize npm executable paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "sideEffects": false,
   "type": "module",
   "bin": {
-    "youtube-mcp-server": "./dist/stdio-server.js",
-    "youtube-mcp-http": "./dist/http-server.js"
+    "youtube-mcp-server": "dist/stdio-server.js",
+    "youtube-mcp-http": "dist/http-server.js"
   },
   "mcpName": "io.github.coyasong/youtube-research",
   "scripts": {


### PR DESCRIPTION
## Summary

- Normalize npm `bin` targets to registry-compatible relative paths.
- Preserve both the stdio `youtube-mcp-server` and HTTP `youtube-mcp-http` commands.

## Root cause

npm 12 auto-corrected targets beginning with `./` during publish and warned that the executable entries were removed from the outgoing manifest.

## Verification

- `npm publish --dry-run --access public` completes without manifest correction warnings.
- `npm test` passes 11/11 tests.
- The real 1.1.0 publish attempt did not create a version because npm rejected it at the account 2FA policy gate.
