### PR TITLE
fix: match case-sensitive MCP Registry namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project are documented here. This project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.1.1] - 2026-07-11
+
+### Fixed
+
+- Match the official MCP Registry namespace to the case-sensitive GitHub account name.
+
+## [1.1.0] - 2026-07-11
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coyasong/youtube-mcp-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coyasong/youtube-mcp-server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coyasong/youtube-mcp-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -15,7 +15,7 @@
     "youtube-mcp-server": "dist/stdio-server.js",
     "youtube-mcp-http": "dist/http-server.js"
   },
-  "mcpName": "io.github.coyasong/youtube-research",
+  "mcpName": "io.github.coyaSONG/youtube-research",
   "scripts": {
     "clean": "rm -rf dist",
     "prebuild": "rm -rf dist && mkdir -p dist",

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.coyasong/youtube-research",
+  "name": "io.github.coyaSONG/youtube-research",
   "title": "YouTube Research MCP",
   "description": "Citation-ready YouTube transcript research and optional channel intelligence for AI agents.",
   "repository": {
     "url": "https://github.com/coyaSONG/youtube-mcp-server",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@coyasong/youtube-mcp-server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -97,7 +97,7 @@ function createServerForSession() {
 app.get('/', (_req, res) => {
   res.status(200).json({
     name: 'YouTube Research MCP',
-    version: '1.1.0',
+    version: '1.1.1',
     mcpEndpoint: '/mcp',
     healthEndpoint: '/health',
     documentation: 'https://github.com/coyaSONG/youtube-mcp-server',

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export default function createServer({ config }: { config: z.infer<typeof config
   // Create the MCP server
   const server = new McpServer({
     name: 'YouTube Research MCP',
-    version: '1.1.0'
+    version: '1.1.1'
   });
 
   // Define resources


### PR DESCRIPTION
## Summary

- Match `mcpName` and `server.json` to the case-sensitive GitHub namespace `io.github.coyaSONG`.
- Bump the patch version to 1.1.1 across npm, MCP runtime metadata, and Registry metadata.
- Record the 1.1.0 and 1.1.1 releases in the changelog.

## Root cause

The official MCP Registry grants this authenticated account access to `io.github.coyaSONG/*`. The 1.1.0 manifest used the lowercase namespace `io.github.coyasong/*`, which the Registry treats as a different publisher and rejects with HTTP 403.

Published npm versions are immutable, so the corrected ownership marker must ship as 1.1.1 before Registry publication.

## Verification

- `npm test` — 11/11 passing
- `npm run test:live` — passing with two public videos
- `npm audit --audit-level=high` — 0 vulnerabilities
- `publint` — all good
- `npm publish --dry-run --access public` — succeeds for 1.1.1
- The official publisher validated the 1.1.0 schema; publication reached and correctly enforced the namespace ownership check.
