### PR TITLE
chore(distribution): add Smithery MCPB publishing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # YouTube Research MCP
 
 [![CI](https://github.com/coyaSONG/youtube-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/coyaSONG/youtube-mcp-server/actions/workflows/ci.yml)
-[![smithery badge](https://smithery.ai/badge/@coyaSONG/youtube-mcp-server)](https://smithery.ai/server/@coyaSONG/youtube-mcp-server)
+[![Smithery](https://smithery.ai/badge/coyaSONG/youtube-mcp-server)](https://smithery.ai/servers/coyaSONG/youtube-mcp-server)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Turn YouTube videos into citation-ready research for Codex, Claude, Cursor, and other MCP clients. Paste a video URL and get transcript evidence with timestamps and links that open at the exact quoted moment.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json",
+  "manifest_version": "0.4",
+  "name": "youtube-research",
+  "display_name": "YouTube Research MCP",
+  "version": "1.1.1",
+  "description": "Citation-ready YouTube research for AI agents with timestamp-linked transcript evidence.",
+  "long_description": "Research YouTube videos without downloading entire transcripts into your agent context. Search captions, return exact timestamp links, compare evidence across videos, extract key moments, and optionally analyze comments, channels, trends, and statistics with a YouTube Data API key.",
+  "author": {
+    "name": "coyaSONG",
+    "url": "https://github.com/coyaSONG"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coyaSONG/youtube-mcp-server"
+  },
+  "homepage": "https://github.com/coyaSONG/youtube-mcp-server",
+  "documentation": "https://github.com/coyaSONG/youtube-mcp-server#readme",
+  "support": "https://github.com/coyaSONG/youtube-mcp-server/issues",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/stdio-server.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/stdio-server.js"
+      ],
+      "env": {
+        "YOUTUBE_API_KEY": "${user_config.youtube_api_key}"
+      }
+    }
+  },
+  "tools_generated": true,
+  "prompts_generated": true,
+  "keywords": [
+    "youtube",
+    "transcript",
+    "research",
+    "citations",
+    "timestamps",
+    "ai-agents",
+    "mcp"
+  ],
+  "license": "MIT",
+  "privacy_policies": [
+    "https://policies.google.com/privacy"
+  ],
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=20"
+    }
+  },
+  "user_config": {
+    "youtube_api_key": {
+      "type": "string",
+      "title": "YouTube Data API key (optional)",
+      "description": "Enables video search, comments, statistics, trends, categories, and channel intelligence. Transcript research works without it.",
+      "required": false,
+      "sensitive": true
+    }
+  }
+}

--- a/tests/metadata.test.mjs
+++ b/tests/metadata.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+async function readJson(path) {
+  return JSON.parse(await readFile(new URL(path, import.meta.url), 'utf8'));
+}
+
+test('distribution manifests describe the same release', async () => {
+  const [packageJson, registryManifest, mcpbManifest] = await Promise.all([
+    readJson('../package.json'),
+    readJson('../server.json'),
+    readJson('../mcpb/manifest.json'),
+  ]);
+
+  assert.equal(registryManifest.version, packageJson.version);
+  assert.equal(mcpbManifest.version, packageJson.version);
+  assert.equal(registryManifest.name, packageJson.mcpName);
+  assert.equal(mcpbManifest.display_name, registryManifest.title);
+  assert.equal(
+    mcpbManifest.repository.url,
+    registryManifest.repository.url,
+  );
+});


### PR DESCRIPTION
## What changed

- add a validated MCPB 0.4 manifest for the local stdio server
- describe optional YouTube API key configuration securely
- keep npm, MCP Registry, and MCPB versions aligned with an automated test
- update the README badge to the canonical Smithery server page

## Why

The current Smithery local-server publishing flow distributes pre-built MCPB bundles. Keeping the manifest in the repository makes the successful 1.1.1 release reproducible and prevents distribution metadata from drifting.

## Impact

Users can discover and install YouTube Research MCP from Smithery while transcript research remains keyless. The optional API key unlocks search and channel analytics.

## Validation

- npm test (12/12)
- MCPB manifest schema validation
- unpacked MCPB stdio initialization smoke test
- Smithery release 0f8da626-21fb-49a4-8aa1-2e2e6610a66b status: SUCCESS