### PR TITLE
test(distribution): add clean-room virtual user smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ npx @modelcontextprotocol/inspector
 ### Install through Smithery
 
 ```bash
+npx -y smithery@latest auth login
 npx -y smithery@latest mcp add coyaSONG/youtube-mcp-server --client claude
 ```
 
@@ -196,6 +197,7 @@ docker run --rm -p 3000:3000 -e YOUTUBE_API_KEY=your_key youtube-research-mcp
 npm run dev             # HTTP server from TypeScript
 npm test                # build and run all tests
 npm run test:live       # live public-video transcript and citation smoke test
+npm run test:user       # clean-room smoke test against the published npm package
 ```
 
 ## API Reference

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prepublishOnly": "npm test",
     "test": "npm run build && node --test tests/*.test.mjs",
     "test:live": "npm run build && node scripts/live-smoke.mjs",
+    "test:user": "node scripts/virtual-user-smoke.mjs",
     "start": "npm run start:http",
     "start:http": "node dist/http-server.js",
     "dev": "npm run dev:http",

--- a/scripts/virtual-user-smoke.mjs
+++ b/scripts/virtual-user-smoke.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const packageSpec = process.env.VIRTUAL_USER_PACKAGE
+  ?? '@coyasong/youtube-mcp-server@latest';
+const video = process.env.LIVE_TEST_VIDEO
+  ?? 'https://www.youtube.com/watch?v=0Uu_VJeVVfo';
+const query = process.env.LIVE_TEST_QUERY ?? 'AI';
+const sandbox = await mkdtemp(join(tmpdir(), 'youtube-research-user-'));
+const transport = new StdioClientTransport({
+  command: 'npx',
+  args: ['-y', packageSpec],
+  env: {
+    ...process.env,
+    HOME: join(sandbox, 'home'),
+    npm_config_cache: join(sandbox, 'npm-cache'),
+  },
+  stderr: 'pipe',
+});
+const client = new Client({ name: 'virtual-user-smoke', version: '1.0.0' });
+
+try {
+  await client.connect(transport);
+
+  const { tools } = await client.listTools();
+  assert.equal(tools.length, 14);
+  assert.ok(tools.some(({ name }) => name === 'research-video'));
+  assert.ok(tools.some(({ name }) => name === 'research-videos'));
+
+  const research = await client.callTool({
+    name: 'research-video',
+    arguments: { video, query, contextLines: 1, maxSegments: 3 },
+  });
+  assert.equal(research.isError, undefined);
+  assert.ok(research.structuredContent.returnedSegments > 0);
+  assert.ok(research.structuredContent.returnedSegments <= 3);
+  assert.match(
+    research.structuredContent.citations[0].sourceUrl,
+    /youtube\.com\/watch\?v=.*[?&]t=\d+s$/,
+  );
+
+  const comparison = await client.callTool({
+    name: 'research-videos',
+    arguments: {
+      videos: [video, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+      query: 'the',
+      contextLines: 0,
+      maxSegmentsPerVideo: 1,
+    },
+  });
+  assert.equal(comparison.isError, undefined);
+  assert.equal(comparison.structuredContent.results.length, 2);
+
+  const apiOnly = await client.callTool({
+    name: 'search-videos',
+    arguments: { query: 'agent engineering', maxResults: 1 },
+  });
+  assert.equal(apiOnly.isError, true);
+  assert.match(apiOnly.content[0].text, /YOUTUBE_API_KEY/);
+
+  const invalidInput = await client.callTool({
+    name: 'research-video',
+    arguments: { video: 'https://example.com/not-youtube' },
+  });
+  assert.equal(invalidInput.isError, true);
+  assert.match(invalidInput.content[0].text, /valid YouTube video ID/);
+
+  console.log(JSON.stringify({
+    status: 'ok',
+    package: packageSpec,
+    toolsDiscovered: tools.length,
+    researchedVideo: research.structuredContent.videoId,
+    citationsReturned: research.structuredContent.returnedSegments,
+    firstCitation: research.structuredContent.citations[0].sourceUrl,
+    comparedVideos: comparison.structuredContent.results.length,
+    missingApiKeyGuidance: 'ok',
+    invalidInputGuidance: 'ok',
+  }, null, 2));
+} finally {
+  await client.close().catch(() => {});
+  await rm(sandbox, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- add a clean-room stdio smoke test against the published npm package
- verify tool discovery, timestamp citations, multi-video research, missing-key guidance, and invalid-input guidance
- document the Smithery authentication prerequisite

## Why

Local tests alone do not prove that a new user can install and use the published artifact. This test uses a temporary HOME and npm cache and launches the public package through npx.

## Validation

- npm run test:user
- npm test (12/12)
- clean-room Smithery bundle installation into a temporary Claude config