### PR TITLE
feat(distribution): ship one-click MCP bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,15 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm audit --audit-level=high
+
+  bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test:mcpb

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -1,0 +1,32 @@
+name: Release MCPB
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag to receive the bundle
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test:mcpb
+      - name: Upload bundle to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: gh release upload "$RELEASE_TAG" artifacts/youtube-research-mcp.mcpb --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ Desktop.ini
 # MCP specific
 mcp-logs/
 .smithery/
+/.mcpb-stage/
+/artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented here. This project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Reproducible MCPB packaging with a clean-room bundle smoke test.
+- One-click GitHub release bundle for Claude Desktop and other MCPB clients.
+
 ## [1.1.1] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ The shortest local install uses stdio and needs no API key:
 codex mcp add youtube-research -- npx -y @coyasong/youtube-mcp-server@latest
 ```
 
+For Claude Desktop and other MCPB-compatible desktop clients, download the
+[latest one-click MCP bundle](https://github.com/coyaSONG/youtube-mcp-server/releases/latest/download/youtube-research-mcp.mcpb)
+and open it. The bundle vendors its runtime dependencies, starts locally over
+stdio, and asks for a YouTube API key only if you want the optional analytics
+tools.
+
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=youtube-research&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40coyasong%2Fyoutube-mcp-server%40latest%22%5D%7D)
 
 Or install from the VS Code command line:
@@ -198,6 +204,7 @@ npm run dev             # HTTP server from TypeScript
 npm test                # build and run all tests
 npm run test:live       # live public-video transcript and citation smoke test
 npm run test:user       # clean-room smoke test against the published npm package
+npm run test:mcpb       # build, unpack, and exercise the installable MCP bundle
 ```
 
 ## API Reference

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "youtube-mcp-server": "dist/stdio-server.js"
       },
       "devDependencies": {
+        "@anthropic-ai/mcpb": "2.1.2",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
         "@types/node": "^26.1.1",
@@ -31,6 +32,37 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-2.1.2.tgz",
+      "integrity": "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.2",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -62,6 +94,244 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -336,6 +606,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -381,6 +661,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -828,6 +1115,22 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -971,6 +1274,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -997,6 +1317,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1341,6 +1671,34 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1413,6 +1771,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1459,6 +1831,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1466,6 +1853,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/gaxios": {
@@ -1623,6 +2025,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/gtoken": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
@@ -1718,6 +2127,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1807,6 +2226,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -1911,6 +2343,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1968,6 +2410,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/object-assign": {
@@ -2069,6 +2521,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proxy-addr": {
@@ -2434,6 +2899,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2485,6 +2960,19 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -2568,6 +3056,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2623,6 +3121,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -2655,6 +3168,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youtubei.js": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "prebuild": "rm -rf dist && mkdir -p dist",
     "build": "npm run build:tsc",
     "build:tsc": "tsc",
+    "prepare:mcpb": "npm run build && node scripts/prepare-mcpb.mjs",
+    "build:mcpb": "npm run prepare:mcpb && mcpb pack .mcpb-stage artifacts/youtube-research-mcp.mcpb",
+    "test:mcpb": "npm run build:mcpb && node scripts/mcpb-smoke.mjs",
     "prepack": "npm run build",
     "prepublishOnly": "npm test",
     "test": "npm run build && node --test tests/*.test.mjs",
@@ -74,10 +77,14 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@anthropic-ai/mcpb": "2.1.2",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/node": "^26.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^7.0.2"
+  },
+  "overrides": {
+    "tmp": "0.2.7"
   }
 }

--- a/scripts/mcpb-smoke.mjs
+++ b/scripts/mcpb-smoke.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(
+  await readFile(join(projectRoot, 'package.json'), 'utf8'),
+);
+const artifact = resolve(
+  process.argv[2] ?? join(projectRoot, 'artifacts', 'youtube-research-mcp.mcpb'),
+);
+const sandbox = await mkdtemp(join(tmpdir(), 'youtube-research-mcpb-'));
+const unpacked = join(sandbox, 'bundle');
+const mcpbCommand = join(
+  projectRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'mcpb.cmd' : 'mcpb',
+);
+
+let client;
+try {
+  execFileSync(mcpbCommand, ['unpack', artifact, unpacked], { stdio: 'inherit' });
+  const manifest = JSON.parse(
+    await readFile(join(unpacked, 'manifest.json'), 'utf8'),
+  );
+  assert.equal(manifest.version, packageJson.version);
+
+  const entryPoint = join(unpacked, manifest.server.entry_point);
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [entryPoint],
+    env: {
+      ...process.env,
+      HOME: join(sandbox, 'home'),
+      YOUTUBE_API_KEY: '',
+    },
+    stderr: 'pipe',
+  });
+  client = new Client({ name: 'mcpb-smoke', version: '1.0.0' });
+  await client.connect(transport);
+
+  const { tools } = await client.listTools();
+  assert.equal(tools.length, 14);
+  assert.ok(tools.some(({ name }) => name === 'research-video'));
+  assert.ok(tools.some(({ name }) => name === 'research-videos'));
+
+  const invalidInput = await client.callTool({
+    name: 'research-video',
+    arguments: { video: 'https://example.com/not-youtube' },
+  });
+  assert.equal(invalidInput.isError, true);
+  assert.match(invalidInput.content[0].text, /valid YouTube video ID/);
+
+  const apiOnly = await client.callTool({
+    name: 'search-videos',
+    arguments: { query: 'agent engineering', maxResults: 1 },
+  });
+  assert.equal(apiOnly.isError, true);
+  assert.match(apiOnly.content[0].text, /YOUTUBE_API_KEY/);
+
+  console.log(JSON.stringify({
+    status: 'ok',
+    artifact,
+    version: manifest.version,
+    toolsDiscovered: tools.length,
+    missingApiKeyGuidance: 'ok',
+    invalidInputGuidance: 'ok',
+  }, null, 2));
+} finally {
+  await client?.close().catch(() => {});
+  await rm(sandbox, { recursive: true, force: true });
+}

--- a/scripts/prepare-mcpb.mjs
+++ b/scripts/prepare-mcpb.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { cp, mkdir, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const stage = join(projectRoot, '.mcpb-stage');
+const artifactDirectory = join(projectRoot, 'artifacts');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const packageJson = JSON.parse(
+  await readFile(join(projectRoot, 'package.json'), 'utf8'),
+);
+const manifest = JSON.parse(
+  await readFile(join(projectRoot, 'mcpb', 'manifest.json'), 'utf8'),
+);
+
+assert.equal(
+  manifest.version,
+  packageJson.version,
+  'MCPB manifest and package versions must match',
+);
+
+await rm(stage, { recursive: true, force: true });
+await mkdir(stage, { recursive: true });
+await mkdir(artifactDirectory, { recursive: true });
+
+for (const file of [
+  'package.json',
+  'package-lock.json',
+  'README.md',
+  'LICENSE',
+  'SECURITY.md',
+]) {
+  await cp(join(projectRoot, file), join(stage, file));
+}
+await cp(join(projectRoot, 'mcpb', 'manifest.json'), join(stage, 'manifest.json'));
+await cp(join(projectRoot, 'dist'), join(stage, 'dist'), { recursive: true });
+
+execFileSync(
+  npmCommand,
+  ['ci', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'],
+  { cwd: stage, stdio: 'inherit' },
+);
+
+console.log(`Prepared MCPB staging directory at ${stage}`);


### PR DESCRIPTION
## What changed

- add a reproducible MCPB staging and packaging pipeline
- vendor production dependencies into an 8.5 MB one-click bundle
- unpack and launch the generated artifact in a clean-room MCP smoke test
- gate pull requests on bundle construction and runtime verification
- upload the stable `youtube-research-mcp.mcpb` asset on GitHub releases
- document the one-click Claude Desktop / MCPB install path

## Why

The repository advertised MCPB support but only contained a manifest; users had no installable `.mcpb` release asset. This completes the promised one-click distribution path and keeps future release assets reproducible.

## User impact

MCPB-compatible desktop clients can download the latest release asset, open it, and run the server locally without cloning the repository or installing npm dependencies. The optional YouTube API key remains optional.

## Verification

- `npm test` — 12 passed
- `npm run test:mcpb` — bundle built, unpacked, server launched, 14 tools discovered, error guidance verified
- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm pack --dry-run`
- Docker production image build
- staged gitleaks scan — no leaks