### PR TITLE
feat(discovery): declare MCPB tool catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. This project follows [S
 
 - Reproducible MCPB packaging with a clean-room bundle smoke test.
 - One-click GitHub release bundle for Claude Desktop and other MCPB clients.
+- Static MCPB capability metadata for all 14 tools so registries can index the
+  server without executing it first.
 
 ## [1.1.1] - 2026-07-11
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -30,7 +30,65 @@
       }
     }
   },
-  "tools_generated": true,
+  "tools": [
+    {
+      "name": "research-video",
+      "description": "Find citation-ready transcript evidence with exact timestamp links; no API key required."
+    },
+    {
+      "name": "research-videos",
+      "description": "Compare timestamp-linked evidence across two to five videos; no API key required."
+    },
+    {
+      "name": "get-video-transcript",
+      "description": "Retrieve a full timestamped transcript in an optional caption language."
+    },
+    {
+      "name": "enhanced-transcript",
+      "description": "Filter, search, segment, and format transcripts from up to five videos."
+    },
+    {
+      "name": "get-key-moments",
+      "description": "Extract concise timestamp-linked moments from a video transcript."
+    },
+    {
+      "name": "get-segmented-transcript",
+      "description": "Split a transcript into time-based sections for structured analysis."
+    },
+    {
+      "name": "search-videos",
+      "description": "Search YouTube with advanced filters; requires a YouTube Data API key."
+    },
+    {
+      "name": "get-video-comments",
+      "description": "Retrieve video comments and optional replies; requires a YouTube Data API key."
+    },
+    {
+      "name": "get-video-stats",
+      "description": "Retrieve video metadata and engagement statistics; requires a YouTube Data API key."
+    },
+    {
+      "name": "get-channel-stats",
+      "description": "Retrieve channel audience and publishing statistics; requires a YouTube Data API key."
+    },
+    {
+      "name": "compare-videos",
+      "description": "Compare engagement statistics across videos; requires a YouTube Data API key."
+    },
+    {
+      "name": "get-trending-videos",
+      "description": "Discover trending videos by region and category; requires a YouTube Data API key."
+    },
+    {
+      "name": "get-video-categories",
+      "description": "List YouTube video categories for a region; requires a YouTube Data API key."
+    },
+    {
+      "name": "analyze-channel-videos",
+      "description": "Analyze recent channel performance trends; requires a YouTube Data API key."
+    }
+  ],
+  "tools_generated": false,
   "prompts_generated": true,
   "keywords": [
     "youtube",

--- a/scripts/mcpb-smoke.mjs
+++ b/scripts/mcpb-smoke.mjs
@@ -48,6 +48,11 @@ try {
 
   const { tools } = await client.listTools();
   assert.equal(tools.length, 14);
+  assert.deepEqual(
+    tools.map(({ name }) => name).sort(),
+    manifest.tools.map(({ name }) => name).sort(),
+    'MCPB capability metadata must match the bundled server',
+  );
   assert.ok(tools.some(({ name }) => name === 'research-video'));
   assert.ok(tools.some(({ name }) => name === 'research-videos'));
 

--- a/tests/metadata.test.mjs
+++ b/tests/metadata.test.mjs
@@ -17,6 +17,12 @@ test('distribution manifests describe the same release', async () => {
   assert.equal(mcpbManifest.version, packageJson.version);
   assert.equal(registryManifest.name, packageJson.mcpName);
   assert.equal(mcpbManifest.display_name, registryManifest.title);
+  assert.equal(mcpbManifest.tools_generated, false);
+  assert.equal(mcpbManifest.tools.length, 14);
+  assert.equal(new Set(mcpbManifest.tools.map(({ name }) => name)).size, 14);
+  assert.ok(
+    mcpbManifest.tools.every(({ name, description }) => name && description),
+  );
   assert.equal(
     mcpbManifest.repository.url,
     registryManifest.repository.url,


### PR DESCRIPTION
## What changed

- declare all 14 fixed MCP tools in the MCPB manifest with concise discovery descriptions
- mark `tools_generated` false because the runtime tool set is static
- enforce exact manifest/runtime tool-name parity in clean-room bundle verification
- add metadata regression checks

## Why

The newly published Smithery local bundle worked, but registry metadata exposed no tools because the manifest claimed they were generated at runtime. Static catalog metadata lets Smithery and other MCPB indexes explain the server before executing it and prevents discovery drift.

## Verification

- MCPB schema validation passed
- `npm test` — 12 passed
- `npm run test:mcpb` — bundled runtime and 14 manifest tools match exactly
- `npm audit --audit-level=low` — 0 vulnerabilities
- staged gitleaks scan — no leaks