### PR TITLE
feat(research): add citation source identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. This project follows [S
 
 - Reproducible MCPB packaging with a clean-room bundle smoke test.
 - One-click GitHub release bundle for Claude Desktop and other MCPB clients.
+- Video title, channel identity, thumbnail, and human-readable labels in
+  citation-ready research results without requiring an API key.
 
 ## [1.1.1] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ codex mcp add youtube-research \
 - `offset`: result offset for pagination
 - `maxSegments`: response cap from 1 to 1,000 (default: 200)
 
-It returns structured JSON containing the canonical video URL, full caption-track duration and segment count, matching transcript segments, timestamps, directly navigable citation URLs, and pagination metadata. For long videos, use a `query` or time window first; follow `nextOffset` only when more evidence is needed.
+It returns structured JSON containing the video title and channel identity, canonical video URL, full caption-track duration and segment count, matching transcript segments, human-readable citation labels, timestamps, directly navigable citation URLs, and pagination metadata. For long videos, use a `query` or time window first; follow `nextOffset` only when more evidence is needed.
 
 ### Compare evidence across videos
 

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -24,6 +24,9 @@ try {
   assert.ok(result.structuredContent.totalAvailableSegments > 0);
   assert.ok(result.structuredContent.returnedSegments > 0);
   assert.ok(result.structuredContent.returnedSegments <= 3);
+  assert.ok(result.structuredContent.source.title.length > 0);
+  assert.match(result.structuredContent.source.videoUrl, /youtube\.com\/watch\?v=/);
+  assert.match(result.structuredContent.citations[0].label, /\[\d{2}:\d{2}\]$/);
   assert.match(result.structuredContent.citations[0].sourceUrl, /[?&]t=\d+s$/);
 
   const fullTranscript = await client.callTool({
@@ -62,6 +65,8 @@ try {
   console.log(JSON.stringify({
     status: 'ok',
     videoId: result.structuredContent.videoId,
+    title: result.structuredContent.source.title,
+    channel: result.structuredContent.source.channelName,
     matches: result.structuredContent.totalAvailableSegments,
     returned: result.structuredContent.returnedSegments,
     firstCitation: result.structuredContent.citations[0].sourceUrl,

--- a/scripts/mcpb-smoke.mjs
+++ b/scripts/mcpb-smoke.mjs
@@ -48,7 +48,10 @@ try {
 
   const { tools } = await client.listTools();
   assert.equal(tools.length, 14);
-  assert.ok(tools.some(({ name }) => name === 'research-video'));
+  const researchTool = tools.find(({ name }) => name === 'research-video');
+  assert.ok(researchTool);
+  assert.ok(researchTool.outputSchema.properties.source);
+  assert.ok(researchTool.outputSchema.properties.citations.items.properties.label);
   assert.ok(tools.some(({ name }) => name === 'research-videos'));
 
   const invalidInput = await client.callTool({

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,15 @@ const READ_ONLY_TOOL_ANNOTATIONS = {
 const researchOutputSchema = {
   videoId: z.string(),
   sourceUrl: z.string().url(),
+  source: z.object({
+    videoId: z.string(),
+    title: z.string(),
+    videoUrl: z.string().url(),
+    channelId: z.string().nullable(),
+    channelName: z.string().nullable(),
+    channelUrl: z.string().url().nullable(),
+    thumbnailUrl: z.string().url().nullable(),
+  }),
   language: z.string(),
   query: z.string().nullable(),
   matchMode: z.enum(['word', 'substring']).nullable(),
@@ -44,6 +53,7 @@ const researchOutputSchema = {
   nextOffset: z.number().int().min(0).nullable(),
   durationSeconds: z.number().min(0),
   citations: z.array(z.object({
+    label: z.string(),
     timestamp: z.string(),
     seconds: z.number().min(0),
     text: z.string(),
@@ -83,17 +93,17 @@ async function researchVideo(
   }
 
   const videoId = extractVideoId(video);
-  const fullTranscript = await youtubeService.getTranscript(videoId, { language });
   const hasFilters = query !== undefined || startSeconds !== undefined || endSeconds !== undefined;
-  const segments = hasFilters
-    ? await youtubeService.getTranscript(videoId, {
-        language,
-        timeRange: startSeconds !== undefined || endSeconds !== undefined
-          ? { start: startSeconds, end: endSeconds }
-          : undefined,
-        search: query ? { query, contextLines, matchMode } : undefined,
-      })
-    : fullTranscript;
+  const research = await youtubeService.getResearchTranscript(videoId, {
+    language,
+    timeRange: hasFilters && (startSeconds !== undefined || endSeconds !== undefined)
+      ? { start: startSeconds, end: endSeconds }
+      : undefined,
+    search: hasFilters && query
+      ? { query, contextLines, matchMode }
+      : undefined,
+  });
+  const { fullTranscript, transcript: segments, source } = research;
   const durationSeconds = fullTranscript.reduce(
     (maximum, segment) => Math.max(maximum, (segment.offset + segment.duration) / 1000),
     0,
@@ -102,6 +112,7 @@ async function researchVideo(
   const citations = selectedSegments.map((segment) => {
     const seconds = segment.offset / 1000;
     return {
+      label: `${source.title} [${formatTime(segment.offset)}]`,
       timestamp: formatTime(segment.offset),
       seconds,
       text: segment.text,
@@ -111,7 +122,8 @@ async function researchVideo(
 
   return {
     videoId,
-    sourceUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    sourceUrl: source.videoUrl,
+    source,
     language: language ?? 'default',
     query: query ?? null,
     matchMode: query ? matchMode : null,

--- a/src/types/youtube-types.ts
+++ b/src/types/youtube-types.ts
@@ -5,6 +5,22 @@ export interface TranscriptSegment {
   videoId?: string; // Added for multi-video transcripts
 }
 
+export interface ResearchSourceMetadata {
+  videoId: string;
+  title: string;
+  videoUrl: string;
+  channelId: string | null;
+  channelName: string | null;
+  channelUrl: string | null;
+  thumbnailUrl: string | null;
+}
+
+export interface ResearchTranscript {
+  fullTranscript: TranscriptSegment[];
+  transcript: TranscriptSegment[];
+  source: ResearchSourceMetadata;
+}
+
 export interface TimeRange {
   start?: number; // Start time in seconds
   end?: number; // End time in seconds

--- a/src/youtube-service.ts
+++ b/src/youtube-service.ts
@@ -1,12 +1,65 @@
 import { google, youtube_v3 } from 'googleapis';
 import NodeCache from 'node-cache';
 import { Innertube } from 'youtubei.js';
-import { TranscriptSegment, TranscriptOptions, FormattedTranscript, TranscriptError, TimeRange, SearchOptions } from './types/youtube-types.js';
+import {
+  TranscriptSegment,
+  TranscriptOptions,
+  FormattedTranscript,
+  TranscriptError,
+  TimeRange,
+  SearchOptions,
+  ResearchSourceMetadata,
+  ResearchTranscript,
+} from './types/youtube-types.js';
 import { Json3CaptionResponse, parseJson3Transcript } from './transcript-parser.js';
 import { segmentTranscript } from './transcript-processing.js';
 
 const TRANSCRIPT_CACHE_TTL = 3600; // Cache transcripts for 1 hour
 const TRANSCRIPT_CACHE_MAX_KEYS = 500;
+
+interface BasicVideoInfo {
+  title?: string;
+  channel_id?: string;
+  author?: string;
+  channel?: {
+    id: string;
+    name: string;
+    url: string;
+  } | null;
+  thumbnail?: Array<{ url: string }>;
+}
+
+interface TranscriptSource {
+  segments: TranscriptSegment[];
+  metadata: ResearchSourceMetadata;
+}
+
+function normalizeYouTubeUrl(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  return new URL(url, 'https://www.youtube.com').toString();
+}
+
+export function createResearchSourceMetadata(
+  videoId: string,
+  basicInfo: BasicVideoInfo,
+): ResearchSourceMetadata {
+  const channelId = basicInfo.channel?.id ?? basicInfo.channel_id ?? null;
+  const thumbnails = basicInfo.thumbnail ?? [];
+  return {
+    videoId,
+    title: basicInfo.title ?? videoId,
+    videoUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    channelId,
+    channelName: basicInfo.channel?.name ?? basicInfo.author ?? null,
+    channelUrl: normalizeYouTubeUrl(
+      basicInfo.channel?.url
+        ?? (channelId ? `/channel/${channelId}` : undefined),
+    ),
+    thumbnailUrl: thumbnails[thumbnails.length - 1]?.url ?? null,
+  };
+}
 
 export class YouTubeService {
   private static readonly transcriptCache = new NodeCache({
@@ -44,7 +97,10 @@ export class YouTubeService {
     return YouTubeService.innertubePromise;
   }
 
-  private async fetchTranscript(videoId: string, language?: string): Promise<TranscriptSegment[]> {
+  private async fetchTranscriptSource(
+    videoId: string,
+    language?: string,
+  ): Promise<TranscriptSource> {
     const innertube = await this.getInnertube();
     const videoInfo = await innertube.getBasicInfo(videoId, { client: 'ANDROID_VR' });
     const tracks = videoInfo.captions?.caption_tracks ?? [];
@@ -88,7 +144,10 @@ export class YouTubeService {
       throw new Error('YouTube returned an empty caption track.');
     }
 
-    return segments;
+    return {
+      segments,
+      metadata: createResearchSourceMetadata(videoId, videoInfo.basic_info),
+    };
   }
 
   async searchVideos(
@@ -204,29 +263,20 @@ export class YouTubeService {
       ? { language: langOrOptions }
       : langOrOptions || {};
 
-    const cacheKey = this.generateTranscriptCacheKey(videoId, options);
-    const cachedTranscript = YouTubeService.transcriptCache.get<TranscriptSegment[]>(cacheKey);
+    const source = await this.loadTranscriptSource(videoId, options);
+    return this.processTranscript(source.segments, options);
+  }
 
-    if (cachedTranscript) {
-      return this.processTranscript(cachedTranscript, options);
-    }
-
-    try {
-      const captions = await this.fetchTranscript(videoId, options.language);
-      YouTubeService.transcriptCache.set(cacheKey, captions);
-
-      return this.processTranscript(captions, options);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      console.error(`Error getting video transcript for ${videoId}:`, error);
-
-      throw new TranscriptError({
-        message: `Failed to fetch transcript: ${errorMessage}`,
-        videoId,
-        options,
-        originalError: error instanceof Error ? error : new Error(errorMessage)
-      });
-    }
+  async getResearchTranscript(
+    videoId: string,
+    options: TranscriptOptions = {},
+  ): Promise<ResearchTranscript> {
+    const source = await this.loadTranscriptSource(videoId, options);
+    return {
+      fullTranscript: source.segments,
+      transcript: this.processTranscript(source.segments, options),
+      source: source.metadata,
+    };
   }
 
   async getEnhancedTranscript(
@@ -637,5 +687,31 @@ export class YouTubeService {
       language: options.language || 'default'
     });
     return `transcript_${videoId}_${optionsString}`;
+  }
+
+  private async loadTranscriptSource(
+    videoId: string,
+    options: TranscriptOptions,
+  ): Promise<TranscriptSource> {
+    const cacheKey = this.generateTranscriptCacheKey(videoId, options);
+    const cachedSource = YouTubeService.transcriptCache.get<TranscriptSource>(cacheKey);
+    if (cachedSource) {
+      return cachedSource;
+    }
+
+    try {
+      const source = await this.fetchTranscriptSource(videoId, options.language);
+      YouTubeService.transcriptCache.set(cacheKey, source);
+      return source;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`Error getting video transcript for ${videoId}:`, error);
+      throw new TranscriptError({
+        message: `Failed to fetch transcript: ${errorMessage}`,
+        videoId,
+        options,
+        originalError: error instanceof Error ? error : new Error(errorMessage),
+      });
+    }
   }
 }

--- a/tests/stdio-server.test.mjs
+++ b/tests/stdio-server.test.mjs
@@ -17,6 +17,8 @@ test('stdio entry point serves the flagship research tool', async () => {
     const researchTool = tools.find((tool) => tool.name === 'research-video');
     assert.ok(researchTool);
     assert.equal(researchTool.annotations.readOnlyHint, true);
+    assert.ok(researchTool.outputSchema.properties.source);
+    assert.ok(researchTool.outputSchema.properties.citations.items.properties.label);
   } finally {
     await client.close();
   }

--- a/tests/video-metadata.test.mjs
+++ b/tests/video-metadata.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createResearchSourceMetadata } from '../dist/youtube-service.js';
+
+test('research source metadata preserves citation identity', () => {
+  assert.deepEqual(
+    createResearchSourceMetadata('abcdefghijk', {
+      title: 'How to evaluate agents',
+      channel: {
+        id: 'UC-research',
+        name: 'Research Channel',
+        url: '/@research-channel',
+      },
+      thumbnail: [
+        { url: 'https://i.ytimg.com/vi/abcdefghijk/default.jpg' },
+        { url: 'https://i.ytimg.com/vi/abcdefghijk/maxresdefault.jpg' },
+      ],
+    }),
+    {
+      videoId: 'abcdefghijk',
+      title: 'How to evaluate agents',
+      videoUrl: 'https://www.youtube.com/watch?v=abcdefghijk',
+      channelId: 'UC-research',
+      channelName: 'Research Channel',
+      channelUrl: 'https://www.youtube.com/@research-channel',
+      thumbnailUrl: 'https://i.ytimg.com/vi/abcdefghijk/maxresdefault.jpg',
+    },
+  );
+});
+
+test('research source metadata degrades safely when optional fields are absent', () => {
+  assert.deepEqual(createResearchSourceMetadata('abcdefghijk', {}), {
+    videoId: 'abcdefghijk',
+    title: 'abcdefghijk',
+    videoUrl: 'https://www.youtube.com/watch?v=abcdefghijk',
+    channelId: null,
+    channelName: null,
+    channelUrl: null,
+    thumbnailUrl: null,
+  });
+});


### PR DESCRIPTION
## What changed

- add structured video title, channel identity, canonical URLs, and thumbnail metadata to `research-video` / `research-videos` results
- add human-readable citation labels such as `Introducing GPT-5 [00:35]`
- cache captions and source metadata together from the same YouTube.js `getBasicInfo` call
- remove the prior duplicate transcript lookup for filtered research
- document and test the expanded structured output

## User impact

Agents can place evidence into reports and notes with enough source identity to understand the citation without making a second metadata call or requiring a YouTube Data API key. Existing fields remain unchanged.

## API impact

Backward-compatible additions to the structured output of `research-video` and each `research-videos` result: `source` plus `citations[].label`.

## Verification

- `npm test` — 14 passed
- `npm run test:live` — title `Introducing GPT-5`, channel `OpenAI`, citations valid, 98.2% focused-response reduction
- `npm run test:mcpb` — bundled output schema verified
- `npm run test:user` — current published package remains healthy
- `npm audit --audit-level=low` — 0 vulnerabilities
- Docker production build
- staged gitleaks scan — no leaks