### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to this project are documented here. This project follows [S
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-12
+
 ### Added
 
 - Reproducible MCPB packaging with a clean-room bundle smoke test.
 - One-click GitHub release bundle for Claude Desktop and other MCPB clients.
 - Video title, channel identity, thumbnail, and human-readable labels in
   citation-ready research results without requiring an API key.
+
+### Changed
+
+- Cache transcript segments and source identity together so focused research
+  needs only one YouTube information request.
 
 ## [1.1.1] - 2026-07-11
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "youtube-research",
   "display_name": "YouTube Research MCP",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Citation-ready YouTube research for AI agents with timestamp-linked transcript evidence.",
   "long_description": "Research YouTube videos without downloading entire transcripts into your agent context. Search captions, return exact timestamp links, compare evidence across videos, extract key moments, and optionally analyze comments, channels, trends, and statistics with a YouTube Data API key.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coyasong/youtube-mcp-server",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coyasong/youtube-mcp-server",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coyasong/youtube-mcp-server",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/coyaSONG/youtube-mcp-server",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@coyasong/youtube-mcp-server",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -97,7 +97,7 @@ function createServerForSession() {
 app.get('/', (_req, res) => {
   res.status(200).json({
     name: 'YouTube Research MCP',
-    version: '1.1.1',
+    version: '1.2.0',
     mcpEndpoint: '/mcp',
     healthEndpoint: '/health',
     documentation: 'https://github.com/coyaSONG/youtube-mcp-server',

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ export default function createServer({ config }: { config: z.infer<typeof config
   // Create the MCP server
   const server = new McpServer({
     name: 'YouTube Research MCP',
-    version: '1.1.1'
+    version: '1.2.0'
   });
 
   // Define resources

--- a/src/youtube-service.ts
+++ b/src/youtube-service.ts
@@ -131,7 +131,7 @@ export class YouTubeService {
     }
 
     const response = await fetch(captionUrl, {
-      headers: { 'user-agent': 'Mozilla/5.0 (compatible; YouTubeResearchMCP/1.1)' },
+      headers: { 'user-agent': 'Mozilla/5.0 (compatible; YouTubeResearchMCP/1.2)' },
     });
     if (!response.ok) {
       throw new Error(`Caption request failed with HTTP ${response.status}.`);


### PR DESCRIPTION
## Summary

Prepare the citation-source and one-click MCPB improvements as release v1.2.0 across npm, runtime, official MCP Registry, MCPB, and changelog metadata.

## Release contents

- one-click MCPB bundle with clean-room runtime verification
- GitHub release automation and Smithery local bundle distribution
- no-key video title, channel identity, thumbnail, and readable citation labels
- a single cached YouTube information request for transcript plus source identity

## Verification

- `npm test` — 14 passed
- `npm run test:mcpb` — v1.2.0 bundle verified
- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm pack --dry-run` — 31 expected files, 38.3 KB package
- staged gitleaks scan — no leaks