### PR TITLE
docs: strengthen adoption and community signals

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our standard
+
+We want this project to be a useful, welcoming place for people researching
+video content and building AI tools. Be respectful, assume good intent, and
+focus criticism on ideas and code rather than people.
+
+Examples of constructive participation include:
+
+- sharing reproducible reports without exposing private data or credentials;
+- explaining tradeoffs and evidence behind a technical suggestion;
+- making room for contributors with different experience levels and
+  communication styles;
+- accepting corrections and resolving disagreements professionally.
+
+Harassment, threats, discrimination, sexualized conduct, deliberate
+misinformation, doxxing, and publication of another person's secrets or
+private data are not acceptable.
+
+## Scope
+
+This standard applies in repository issues, pull requests, discussions,
+reviews, release channels, and other spaces where someone represents this
+project.
+
+## Reporting and enforcement
+
+Report conduct or security-sensitive concerns privately through the contact
+method in [SECURITY.md](SECURITY.md). Do not open a public issue containing
+personal information, credentials, or unreleased vulnerability details.
+
+Maintainers may edit or remove content, close or lock threads, reject
+contributions, or temporarily or permanently restrict participation when
+behavior harms the community or project. Reports will be reviewed in context,
+kept as private as practical, and handled without retaliation against a
+good-faith reporter.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # YouTube Research MCP
 
 [![CI](https://github.com/coyaSONG/youtube-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/coyaSONG/youtube-mcp-server/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40coyasong%2Fyoutube-mcp-server?logo=npm)](https://www.npmjs.com/package/@coyasong/youtube-mcp-server)
+[![npm downloads](https://img.shields.io/npm/dm/%40coyasong%2Fyoutube-mcp-server?logo=npm)](https://www.npmjs.com/package/@coyasong/youtube-mcp-server)
+[![GitHub stars](https://img.shields.io/github/stars/coyaSONG/youtube-mcp-server?style=flat&logo=github)](https://github.com/coyaSONG/youtube-mcp-server/stargazers)
 [![Smithery](https://smithery.ai/badge/coyaSONG/youtube-mcp-server)](https://smithery.ai/servers/coyaSONG/youtube-mcp-server)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -32,8 +35,8 @@ The included live smoke test asks a focused question about a public video and co
 | Response | Characters returned |
 |---|---:|
 | Full transcript | 85,518 |
-| `research-video` (3 citations) | 970 |
-| Reduction | **98.9%** |
+| `research-video` (3 citations with source identity) | 1,550 |
+| Reduction | **98.2%** |
 
 This measures response characters, not model-specific tokens. Reproduce it against the default public fixture—or substitute your own video and query:
 
@@ -177,6 +180,10 @@ It returns structured JSON containing the video title and channel identity, cano
 }
 ```
 
+See [YouTube Research Recipes](docs/recipes.md) for copy-paste workflows for
+fact-checking claims, comparing interviews, navigating long talks, researching
+multilingual captions, and building citation-ready notes.
+
 ## Capability modes
 
 | Capability | No-key mode | With `YOUTUBE_API_KEY` |
@@ -186,6 +193,10 @@ It returns structured JSON containing the video title and channel identity, cano
 | Video/channel metadata, statistics, trends, and comparisons | No | Yes |
 
 Captions must be available for the requested video. Age-restricted, private, region-restricted, or caption-disabled videos may not return a transcript.
+
+If this project saves you research time, consider
+[starring the repository](https://github.com/coyaSONG/youtube-mcp-server) so
+other agent builders can discover it.
 
 ## Docker
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,80 @@
+# YouTube Research Recipes
+
+These recipes work with `research-video` and `research-videos` without a
+YouTube Data API key. Replace the example URLs with your own sources.
+
+## Fact-check a claim
+
+```text
+Use research-video on https://youtu.be/VIDEO_ID.
+Find evidence about "evaluation" and return the three strongest excerpts.
+For each excerpt include its citation label, exact timestamp link, and one
+sentence explaining whether it supports or contradicts the claim.
+```
+
+Use `matchMode: "word"`, `contextLines: 2`, and `maxSegments: 3` when calling
+the tool directly.
+
+## Compare the same topic across sources
+
+```text
+Use research-videos to compare these interviews:
+- https://youtu.be/VIDEO_ONE
+- https://youtu.be/VIDEO_TWO
+
+Find what each says about "agents". Make a two-column evidence table with
+video title, channel, quoted text, and timestamp link. Call out agreements and
+contradictions without inventing conclusions beyond the cited excerpts.
+```
+
+## Navigate a long talk without loading the full transcript
+
+Start with a focused query and a small result cap:
+
+```json
+{
+  "video": "https://youtu.be/VIDEO_ID",
+  "query": "benchmark",
+  "contextLines": 1,
+  "maxSegments": 5
+}
+```
+
+If the result is truncated, continue from `nextOffset`. Use `startSeconds` and
+`endSeconds` when you already know the relevant part of the video.
+
+## Research captions in another language
+
+```text
+Research https://youtu.be/VIDEO_ID using Korean captions (`language: "ko"`).
+Find references to "안전" and keep the original Korean evidence with exact
+timestamp links. Summarize the evidence in English only after citing it.
+```
+
+Caption availability and translation depend on the video. The tool returns a
+clear error when YouTube does not expose a usable track.
+
+## Build a citation-ready note
+
+The structured result contains source identity once per video and compact
+citations underneath it:
+
+```json
+{
+  "source": {
+    "title": "Introducing GPT-5",
+    "channelName": "OpenAI",
+    "videoUrl": "https://www.youtube.com/watch?v=0Uu_VJeVVfo"
+  },
+  "citations": [
+    {
+      "label": "Introducing GPT-5 [00:35]",
+      "text": "...caption evidence...",
+      "sourceUrl": "https://www.youtube.com/watch?v=0Uu_VJeVVfo&t=35s"
+    }
+  ]
+}
+```
+
+Keep the timestamp URL with every excerpt so readers can verify the evidence
+in context.


### PR DESCRIPTION
## What changed

- add live npm version/download and GitHub star badges
- publish copy-paste recipes for fact checking, cross-video comparison, long-video navigation, multilingual research, and citation-ready notes
- add a project-specific Code of Conduct and private reporting guidance
- add a lightweight star/discovery call to action
- update the benchmark table to the current 1,550-character, 98.2% reduction result with source identity included

## Why

The repository receives package usage but very few GitHub page views. These changes make trust, adoption, and practical outcomes legible to first-time visitors while bringing the GitHub Community Profile from 85% toward complete.

## Verification

- recipe and Code of Conduct links checked
- latest MCPB and Smithery URLs return successfully
- npm package dry run includes `docs/recipes.md`
- staged gitleaks scan — no leaks
- README VS Code deep link excluded from automated link checking because it redirects to the custom `vscode:mcp` protocol