### PR TITLE
ci: automate trusted release publishing

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -1,4 +1,4 @@
-name: Release MCPB
+name: Release
 
 on:
   release:
@@ -12,21 +12,88 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
 
 jobs:
-  bundle:
+  publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    environment: release
+    env:
+      SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: npm
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - run: npm ci
-      - run: npm run test:mcpb
+      - name: Verify release version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          release_version="${{ github.event.release.tag_name || inputs.tag }}"
+          release_version="${release_version#v}"
+          test "$package_version" = "$release_version"
+      - name: Test package and MCPB bundle
+        run: |
+          npm test
+          npm run test:mcpb
+      - name: Check npm release
+        id: npm-release
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish package to npm with OIDC
+        if: steps.npm-release.outputs.published != 'true'
+        run: npm publish --access public
+      - name: Check MCP Registry release
+        id: mcp-release
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          registry_url='https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.coyaSONG%2Fyoutube-research&limit=100'
+          if curl --fail --silent --show-error "$registry_url" \
+            | jq --exit-status --arg version "$package_version" \
+              'any(.servers[]?; .server.name == "io.github.coyaSONG/youtube-research" and .server.version == $version)' \
+              >/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install MCP Registry publisher
+        if: steps.mcp-release.outputs.published != 'true'
+        shell: bash
+        run: |
+          curl --fail --location --silent --show-error \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz \
+            --output /tmp/mcp-publisher.tar.gz
+          echo 'ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac  /tmp/mcp-publisher.tar.gz' \
+            | sha256sum --check
+          tar -xzf /tmp/mcp-publisher.tar.gz mcp-publisher
+      - name: Publish to the official MCP Registry with OIDC
+        if: steps.mcp-release.outputs.published != 'true'
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
       - name: Upload bundle to the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: gh release upload "$RELEASE_TAG" artifacts/youtube-research-mcp.mcpb --clobber
+      - name: Publish bundle to Smithery
+        if: env.SMITHERY_API_KEY != ''
+        run: npx -y @smithery/cli@4.11.1 --json mcp publish artifacts/youtube-research-mcp.mcpb -n coyaSONG/youtube-mcp-server

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ npm run test:user       # clean-room smoke test against the published npm packag
 npm run test:mcpb       # build, unpack, and exercise the installable MCP bundle
 ```
 
+Maintainers can follow the [release guide](docs/releasing.md). Published GitHub
+releases run the complete npm, MCP Registry, MCPB, and Smithery delivery pipeline.
+
 ## API Reference
 
 ### Resources

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,57 @@
+# Releasing
+
+Releases are designed to run unattended after their one-time trust setup. The
+`Release` GitHub Actions workflow validates the tag and package versions, runs
+the package and MCPB smoke tests, and then delivers the release to:
+
+1. npm through OpenID Connect (OIDC) trusted publishing
+2. the official MCP Registry through GitHub OIDC
+3. the GitHub release as an installable MCPB asset
+4. Smithery when the `SMITHERY_API_KEY` repository secret is available
+
+The workflow checks npm and the MCP Registry before publishing, so rerunning a
+partially completed release does not attempt to overwrite an existing version.
+GitHub concurrency also prevents two jobs for the same tag from publishing at
+the same time.
+
+## One-time setup
+
+Configure `@coyasong/youtube-mcp-server` on npm with this trusted publisher:
+
+| Setting | Value |
+|---|---|
+| Provider | GitHub Actions |
+| Organization or user | `coyaSONG` |
+| Repository | `youtube-mcp-server` |
+| Workflow filename | `release-mcpb.yml` |
+| Environment | `release` |
+| Allowed action | `npm publish` |
+
+The workflow uses a GitHub-hosted runner and grants only `contents: write` and
+`id-token: write`. No npm token is stored in GitHub. After one successful OIDC
+release, npm's publishing access should be set to require 2FA and disallow
+traditional tokens.
+
+Add a Smithery API key with server write access as the `SMITHERY_API_KEY`
+repository secret. This is the only long-lived release credential; npm and the
+official MCP Registry use short-lived OIDC credentials.
+
+## Publish a version
+
+1. Update the version in `package.json`, `package-lock.json`, `server.json`, and
+   `mcpb/manifest.json`, plus runtime version strings and `CHANGELOG.md`.
+2. Merge the version PR only after CI succeeds.
+3. Create a GitHub release whose tag is exactly `v` followed by the package
+   version, for example `v1.3.0`.
+4. Publish the GitHub release.
+5. Confirm the `Release` workflow succeeds.
+
+The workflow rejects mismatched tag and package versions before any publish
+step. It also supports manual reruns with the existing release tag through
+`workflow_dispatch`.
+
+## Recovery
+
+Rerun the same workflow with the same tag. Already-published npm and MCP
+Registry versions are skipped, while the GitHub MCPB asset is safely replaced.
+If Smithery is temporarily unavailable, rerun after it recovers.


### PR DESCRIPTION
## Summary

- turn the existing MCPB workflow into an unattended release pipeline
- publish npm and the official MCP Registry with short-lived GitHub OIDC credentials
- upload the verified MCPB bundle and optionally publish it to Smithery
- skip already-published destinations so failed releases can be safely rerun
- document the one-time trust setup and recovery flow

## Why

The previous release process depended on interactive browser authentication for npm, the MCP Registry, and Smithery. That made releases stop whenever the maintainer was away. npm and the MCP Registry both support GitHub OIDC, so they can authenticate a specific workflow without stored publishing tokens.

## User and maintainer impact

Publishing a GitHub release now drives the full distribution pipeline. Version mismatches fail before publishing, same-tag runs are serialized, and retries preserve completed destinations. Smithery remains optional until its repository secret is configured.

## Verification

- `npm test` — 14/14 passed
- `npm run test:mcpb` — bundle built, unpacked, and discovered all 14 tools
- `npm audit --audit-level=high` — 0 vulnerabilities
- workflow YAML parsed successfully
- `git diff --check`
