### PR TITLE
fix: restrict HTTP CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ export SESSION_IDLE_TIMEOUT_MS=1800000
 npm start
 ```
 
+Browser origins are denied by default. `CORS_ORIGIN` accepts a comma-separated
+allowlist of exact `http://` or `https://` origins; wildcard origins are rejected.
+
 Connect Codex using an environment variable rather than writing the secret into its configuration:
 
 ```bash

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -23,9 +23,43 @@ if (!Number.isInteger(port) || port < 1 || port > 65535) {
 
 const youtubeApiKey = process.env.YOUTUBE_API_KEY;
 const bearerToken = process.env.MCP_BEARER_TOKEN;
-const corsOrigin = process.env.CORS_ORIGIN ?? '*';
 const maxSessions = Number(process.env.MAX_SESSIONS ?? '100');
 const sessionIdleTimeoutMs = Number(process.env.SESSION_IDLE_TIMEOUT_MS ?? '1800000');
+
+function parseCorsOrigins(value: string | undefined): Set<string> {
+  if (!value) {
+    return new Set();
+  }
+
+  const origins = value.split(',').map((origin) => origin.trim()).filter(Boolean);
+  return new Set(origins.map((origin) => {
+    if (origin === '*') {
+      throw new Error('CORS_ORIGIN must list explicit origins; wildcard access is not supported.');
+    }
+
+    const parsed = new URL(origin);
+    if (
+      (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')
+      || parsed.username
+      || parsed.password
+      || parsed.pathname !== '/'
+      || parsed.search
+      || parsed.hash
+    ) {
+      throw new Error(`Invalid CORS origin: ${origin}`);
+    }
+
+    return parsed.origin;
+  }));
+}
+
+let allowedCorsOrigins: Set<string>;
+try {
+  allowedCorsOrigins = parseCorsOrigins(process.env.CORS_ORIGIN);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : 'Invalid CORS_ORIGIN configuration.');
+  process.exit(1);
+}
 
 if (!Number.isInteger(maxSessions) || maxSessions < 1) {
   console.error('MAX_SESSIONS must be a positive integer.');
@@ -43,7 +77,9 @@ const sessions = new Map<string, SessionContext>();
 app.disable('x-powered-by');
 app.use(express.json({ limit: '4mb' }));
 app.use(cors({
-  origin: corsOrigin,
+  origin(origin, callback) {
+    callback(null, !origin || allowedCorsOrigins.has(origin));
+  },
   exposedHeaders: ['Mcp-Session-Id']
 }));
 

--- a/tests/http-server.test.mjs
+++ b/tests/http-server.test.mjs
@@ -33,13 +33,15 @@ async function waitForHealth(baseUrl) {
 
 test('HTTP server exposes health and validates MCP sessions', async (t) => {
   const port = await reservePort();
+  const env = {
+    ...process.env,
+    PORT: String(port),
+    YOUTUBE_API_KEY: 'test-key',
+    MCP_BEARER_TOKEN: 'test-token',
+  };
+  delete env.CORS_ORIGIN;
   const child = spawn(process.execPath, ['dist/http-server.js'], {
-    env: {
-      ...process.env,
-      PORT: String(port),
-      YOUTUBE_API_KEY: 'test-key',
-      MCP_BEARER_TOKEN: 'test-token',
-    },
+    env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
@@ -56,6 +58,11 @@ test('HTTP server exposes health and validates MCP sessions', async (t) => {
   assert.equal(rootResponse.status, 200);
   assert.equal(rootResponse.headers.get('x-powered-by'), null);
   assert.equal((await rootResponse.json()).mcpEndpoint, '/mcp');
+
+  const crossOriginResponse = await fetch(baseUrl, {
+    headers: { origin: 'https://untrusted.example' },
+  });
+  assert.equal(crossOriginResponse.headers.get('access-control-allow-origin'), null);
 
   assert.deepEqual(await healthResponse.json(), {
     status: 'ok',
@@ -108,6 +115,41 @@ test('HTTP server exposes health and validates MCP sessions', async (t) => {
     },
   });
   assert.equal(missingSessionResponse.status, 404);
+});
+
+test('HTTP server only emits CORS headers for configured exact origins', async (t) => {
+  const port = await reservePort();
+  const child = spawn(process.execPath, ['dist/http-server.js'], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      CORS_ORIGIN: 'https://client.example, http://localhost:5173',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  t.after(async () => {
+    if (child.exitCode === null) {
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+    }
+  });
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForHealth(baseUrl);
+
+  const allowedResponse = await fetch(baseUrl, {
+    headers: { origin: 'https://client.example' },
+  });
+  assert.equal(
+    allowedResponse.headers.get('access-control-allow-origin'),
+    'https://client.example'
+  );
+
+  const deniedResponse = await fetch(baseUrl, {
+    headers: { origin: 'https://untrusted.example' },
+  });
+  assert.equal(deniedResponse.headers.get('access-control-allow-origin'), null);
 });
 
 test('HTTP server starts in transcript-only mode without an API key', async (t) => {


### PR DESCRIPTION
Denies browser cross-origin access by default, validates an exact HTTP/HTTPS origin allowlist, rejects wildcards, and adds end-to-end HTTP regression coverage.

Validation: npm test